### PR TITLE
Sets the plugin scope to plugin's variables.

### DIFF
--- a/test/worker_test.js
+++ b/test/worker_test.js
@@ -49,8 +49,10 @@ describe('template worker test example', function () {
     };
     process.env.strider_server_name = 'http://example.com';
     config = {
-      environment: 'test message',
-      prepare: 'test message'
+      template: {
+        environment: 'test message',
+        prepare: 'test message'
+      }
     };
     //_.each(schema, function(v,k) { config[k] = v.default });
     //config.token = 'token';

--- a/worker.js
+++ b/worker.js
@@ -40,16 +40,16 @@ module.exports = {
       // or a fn(context, done(err, didrun))
 
       //string style
-      environment: `echo "${config.environment}"`,
+      environment: `echo "${config.template.environment}"`,
       //object style
       prepare: {
         command: 'echo',
-        args: [`"${config.prepare}"`]
+        args: [`"${config.template.prepare}"`]
       },
       //function style (calling done is a MUST)
       test: function (context, done) {
         //this will show up in the terminal log as 'info'
-        debug(config.test);
+        debug(config.template.test);
 
         //demonstration of how to perform async tasks, finishing with a call to done()
         checkSomething(context, function (shouldDoThings) {
@@ -66,8 +66,8 @@ module.exports = {
           });
         });
       },
-      deploy: `echo "${config.deploy}"`,
-      cleanup: `echo "${config.cleanup}"`
+      deploy: `echo "${config.template.deploy}"`,
+      cleanup: `echo "${config.template.cleanup}"`
     });
   },
   // this is only used if there is _no_ plugin configuration for a


### PR DESCRIPTION
When the job is run at first with the plugin. Wrong variable scope is used.

![2017-04-26 08 43 36](https://cloud.githubusercontent.com/assets/1412751/25419715/f1b18e9a-2a5c-11e7-8e15-042c3ee10811.png)

After the changes are applied. It have to look well.
![2017-04-26 08 42 32](https://cloud.githubusercontent.com/assets/1412751/25419716/f1e4e038-2a5c-11e7-84cc-e9c67490b529.png)

